### PR TITLE
Add support for enclosed ' ' parameters in MongoD

### DIFF
--- a/lib/common/odata_common.js
+++ b/lib/common/odata_common.js
@@ -109,7 +109,14 @@ function _getIdByPropertyType(sRawId, property) {
             id = /^[0-9]+.[0-9]+/g.exec(sRawId)[0];
             break;
         default:
-            id = sRawId;
+            if (property.generated === true) {
+                if (sRawId.charAt(0) === "'") {
+                    id = (/^['](.*)[']$/g.exec(sRawId) || [undefined, undefined])[1];
+                }
+            }
+            else {
+                id = sRawId;
+            }
             break;
     }
     return id;

--- a/lib/common/odata_common.js
+++ b/lib/common/odata_common.js
@@ -109,7 +109,7 @@ function _getIdByPropertyType(sRawId, property) {
             id = /^[0-9]+.[0-9]+/g.exec(sRawId)[0];
             break;
         default:
-            if (property.generated === true) {
+            if (property.generated === true && typeof sRawId !== "undefined"){
                 if (sRawId.charAt(0) === "'") {
                     id = (/^['](.*)[']$/g.exec(sRawId) || [undefined, undefined])[1];
                 }

--- a/lib/common/odata_common.ts
+++ b/lib/common/odata_common.ts
@@ -224,7 +224,17 @@ function _getIdByPropertyType(sRawId, property) {
 		 id = /^[0-9]+.[0-9]+/g.exec(sRawId)[0];
 		break;
 	default:
-		id = sRawId;
+		//for MongoDB generated id collumns
+		if(property.generated === true){
+			//if URL starts with ', needs to work too
+			if(sRawId.charAt(0) === "'"){
+				//search for anything enclosed by ''
+				id = (/^['](.*)[']$/g.exec(sRawId)||[undefined, undefined])[1];
+			}
+		}else{
+			//other cases, validating type Edm type
+			id = sRawId;
+		}
 		break;
 	}
 	return id;

--- a/lib/common/odata_common.ts
+++ b/lib/common/odata_common.ts
@@ -225,7 +225,7 @@ function _getIdByPropertyType(sRawId, property) {
 		break;
 	default:
 		//for MongoDB generated id collumns
-		if(property.generated === true){
+		if(property.generated === true && typeof sRawId !== "undefined"){
 			//if URL starts with ', needs to work too
 			if(sRawId.charAt(0) === "'"){
 				//search for anything enclosed by ''


### PR DESCRIPTION
Creating some tests with MongoDB I was looked a problem with id keys enclosed with " ' ".
In collection document the meta link for individual entries are not working in these cases.