### PR TITLE
Adjusting for Edm.Int32 key components

### DIFF
--- a/lib/base/get/odata_get.js
+++ b/lib/base/get/odata_get.js
@@ -134,10 +134,22 @@ var ODataGetBase = (function (_super) {
                             var result = new CollectionResult();
                             ModelClass.find(filter).then((function (data) {
                                 data.forEach((function (object, idx, arr) {
-                                    object.__data.__metadata = {
-                                        uri: commons.getBaseURL(req) + '/' + commons.getPluralForModel(ModelClass) + '(\'' + object.getId() + '\')',
-                                        type: constants.ODATA_NAMESPACE + '.' + ModelClass.definition.name
-                                    };
+                                    var propertyType = commons.convertType(ModelClass.definition._ids[0].property);
+                                    switch (propertyType) {
+                                        case "Edm.Decimal":
+                                        case "Edm.Int32":
+                                            object.__data.__metadata = {
+                                                uri: commons.getBaseURL(req) + '/' + commons.getPluralForModel(ModelClass) + '(' + object.getId() + ')',
+                                                type: constants.ODATA_NAMESPACE + '.' + ModelClass.definition.name
+                                            };
+                                            break;
+                                        default:
+                                            object.__data.__metadata = {
+                                                uri: commons.getBaseURL(req) + '/' + commons.getPluralForModel(ModelClass) + '(\'' + object.getId() + '\')',
+                                                type: constants.ODATA_NAMESPACE + '.' + ModelClass.definition.name
+                                            };
+                                            break;
+                                    }
                                     for (var rel in ModelClass.relations) {
                                         _this._createDeferredObject(object, rel, req, ModelClass, object.getId());
                                     }
@@ -284,11 +296,24 @@ var ODataGetBase = (function (_super) {
     };
     ODataGetBase.prototype._createDeferredObject = function (instance, rel, req, ModelClass, id) {
         if (!instance.__data[rel]) {
-            instance.__data[rel] = {
-                __deferred: {
-                    uri: commons.getBaseURL(req) + '/' + commons.getPluralForModel(ModelClass) + '(\'' + id + '\')/' + rel
-                }
-            };
+            var propertyType = commons.convertType(ModelClass.definition._ids[0].property);
+            switch (propertyType) {
+                case "Edm.Decimal":
+                case "Edm.Int32":
+                    instance.__data[rel] = {
+                        __deferred: {
+                            uri: commons.getBaseURL(req) + '/' + commons.getPluralForModel(ModelClass) + '(' + id + ')/' + rel
+                        }
+                    };
+                    break;
+                default:
+                    instance.__data[rel] = {
+                        __deferred: {
+                            uri: commons.getBaseURL(req) + '/' + commons.getPluralForModel(ModelClass) + '(\'' + id + '\')/' + rel
+                        }
+                    };
+                    break;
+            }
         }
     };
     ODataGetBase.prototype._getServiceDocument = function (req, res) {


### PR DESCRIPTION
When you try to use a entity with an ID as Edm.Int32 with key, it was generating like **/EntityCollection('n')** instead **/EntityCollection(n).** 

This behavior breaks SAPUI5 command: this.getView().getElementBinding().getPath().

This fixes this situation.