### PR TITLE
Fixed issue with deprecated '.find' (when retrieving a method from lb.Class) in Loopback v.3

### DIFF
--- a/lib/base/get/odata_get.js
+++ b/lib/base/get/odata_get.js
@@ -490,6 +490,7 @@ var ODataGetBase = (function (_super) {
                                 result.data = instance.toJSON();
                                 for (var rel in ModelClass.relations) {
                                     _this._createMetadataForExpanded(instance, rel, req, ModelClass.relations[rel].modelTo, id, result.data);
+                                    result.data[rel] = { results: result.data[rel] };
                                 }
                                 var propertyType = commons.convertType(ModelClass.definition._ids[0].property);
                                 var sKey = void 0;

--- a/lib/base/get/odata_get.js
+++ b/lib/base/get/odata_get.js
@@ -1,14 +1,23 @@
 "use strict";
-var __extends = (this && this.__extends) || function (d, b) {
-    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
-    function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-};
-var parser = require('odata-parser');
-var BaseRequestHandler = require('../BaseRequestHandler');
-var commons = require('../../common/odata_common');
-var constants = require('../../constants/odata_constants');
-var req_header = require('../../common/odata_req_header');
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var parser = require("odata-parser");
+var BaseRequestHandler = require("../BaseRequestHandler");
+var commons = require("../../common/odata_common");
+var constants = require("../../constants/odata_constants");
+var req_header = require("../../common/odata_req_header");
 var BaseRequestHandler_1 = require("../BaseRequestHandler");
 var odata_enums_1 = require("../../constants/odata_enums");
 var CollectionResult = (function () {
@@ -108,8 +117,8 @@ exports.ServiceDocumentResult = ServiceDocumentResult;
 var ODataGetBase = (function (_super) {
     __extends(ODataGetBase, _super);
     function ODataGetBase() {
-        _super.call(this);
-        this._createMetadataForExpanded = function (instance, rel, req, ModelClass, id, expandedData) {
+        var _this = _super.call(this) || this;
+        _this._createMetadataForExpanded = function (instance, rel, req, ModelClass, id, expandedData) {
             if (expandedData instanceof Array) {
                 if (expandedData.length === 0) {
                     return;
@@ -257,13 +266,18 @@ var ODataGetBase = (function (_super) {
                 }
             }
         };
+        return _this;
     }
     ;
     ODataGetBase.prototype._getCollectionData = function (req, res) {
         var _this = this;
         return new Promise(function (resolve, reject) {
+            var that = _this;
             commons.getRequestModelClass(req.app.models, req.params[0]).then((function (oResult) {
                 var _this = this;
+                if (oResult.through) {
+                    return that._getM2MCollectionData(req, res, oResult, resolve, reject);
+                }
                 var ModelClass = oResult.modelClass;
                 try {
                     if (ModelClass) {
@@ -389,6 +403,128 @@ var ODataGetBase = (function (_super) {
                 reject(Error(error));
             });
         });
+    };
+    ;
+    ODataGetBase.prototype._getM2MCollectionData = function (req, res, oResult, resolve, reject) {
+        var _this = this;
+        var ModelClass = oResult.modelClass;
+        var RelationModelClass = oResult.relationModelClass;
+        try {
+            if (ModelClass) {
+                ModelClass.findById(oResult.requestId)
+                    .then(function (BaseInstance) {
+                    var _maxpagesize;
+                    var reqHeaderArr = req_header.getPreferHeader(req);
+                    reqHeaderArr.forEach(function (obj, idx, arr) {
+                        if (obj[0] === 'maxpagesize') {
+                            _maxpagesize = obj[1];
+                        }
+                    });
+                    var filter = {};
+                    filter = _applyFilter.call(_this, req, filter);
+                    if (req.query.$count !== undefined) {
+                        if (req.accepts("text/plain")) {
+                            var oCountFilter = filter.where;
+                            BaseInstance[oResult.relationName].count(oCountFilter, function (err, count) {
+                                res.set('Content-Type', 'text/plain');
+                                res.send(count.toString());
+                            });
+                        }
+                        else {
+                            res.sendStatus(415);
+                        }
+                    }
+                    else {
+                        var nextLink;
+                        if (req.query.$top) {
+                            filter.limit = req.query.$top;
+                        }
+                        if (req.query.$skip || req.query.$skiptoken) {
+                            filter.skip = req.query.$skip || req.query.$skiptoken;
+                        }
+                        if (!filter.limit || filter.limit > _this.oDataServerConfig.maxpagesize || (_maxpagesize && filter.limit > _maxpagesize)) {
+                            var effectiveMaxSize = _this.oDataServerConfig.maxpagesize;
+                            if (_maxpagesize && effectiveMaxSize && parseInt(_maxpagesize) < parseInt(effectiveMaxSize)) {
+                                effectiveMaxSize = _maxpagesize;
+                            }
+                            if (!filter.limit) {
+                                var _skiptoken = req.query.$skiptoken;
+                                _skiptoken = (!isNaN(_skiptoken) ? _skiptoken + parseInt(effectiveMaxSize) : parseInt(effectiveMaxSize));
+                                nextLink = commons.getBaseURL(req) + '/' + commons.getPluralForModel(RelationModelClass) + '?$skiptoken=' + _skiptoken;
+                                if (nextLink) {
+                                    var nlFilter = {};
+                                    nlFilter.skip = _skiptoken;
+                                    nlFilter.limit = 1;
+                                    BaseInstance[oResult.relationName].find(nlFilter, function (err, data) {
+                                        if (data.length === 0) {
+                                            nextLink = undefined;
+                                        }
+                                    });
+                                }
+                                filter.limit = effectiveMaxSize;
+                                res.set('Preference-Applied', 'odata.maxpagesize=' + effectiveMaxSize);
+                            }
+                        }
+                        filter = _applySelect.call(_this, req, filter);
+                        filter = _applyExpand.call(_this, req, filter);
+                        console.log("filter: " + JSON.stringify(filter));
+                        filter = _applyOrderBy.call(_this, req, filter);
+                        var result = new CollectionResult();
+                        BaseInstance[oResult.relationName].find(filter).then((function (data) {
+                            data.forEach((function (object, idx, arr) {
+                                var propertyType = commons.convertType(ModelClass.definition._ids[0].property);
+                                switch (propertyType) {
+                                    case odata_enums_1.ODataType.EDM_DECIMAL:
+                                    case odata_enums_1.ODataType.EDM_INT32:
+                                        object.__data.__metadata = {
+                                            uri: commons.getBaseURL(req) + '/' + commons.getPluralForModel(RelationModelClass) + '(' + object.getId() + ')',
+                                            type: constants.ODATA_NAMESPACE + '.' + RelationModelClass.definition.name
+                                        };
+                                        break;
+                                    default:
+                                        object.__data.__metadata = {
+                                            uri: commons.getBaseURL(req) + '/' + commons.getPluralForModel(RelationModelClass) + '(\'' + object.getId() + '\')',
+                                            type: constants.ODATA_NAMESPACE + '.' + RelationModelClass.definition.name
+                                        };
+                                        break;
+                                }
+                                for (var rel in RelationModelClass.relations) {
+                                    _this._createDeferredObject(object, rel, req, RelationModelClass, object.getId());
+                                }
+                                for (var rel in oResult.relationModelClass.relations) {
+                                    _this._createMetadataForExpanded(object, rel, req, RelationModelClass.relations[rel].modelTo, object.getId(), data);
+                                }
+                            }).bind(_this));
+                            result.data = data;
+                            if (nextLink) {
+                                result.nextLink = nextLink;
+                            }
+                            return result;
+                        }).bind(_this)).then(function (result) {
+                            if (req.query.$inlinecount) {
+                                BaseInstance[oResult.relationName].count().then(function (resultCount) {
+                                    result.count = resultCount;
+                                    resolve(result);
+                                });
+                            }
+                            else {
+                                resolve(result);
+                            }
+                        }).catch(function (err) {
+                            console.error(err);
+                            reject(err);
+                        });
+                    }
+                })
+                    .catch(reject);
+            }
+            else {
+                reject(Error("request failed"));
+            }
+        }
+        catch (e) {
+            reject(e);
+        }
     };
     ;
     ODataGetBase.prototype._getCollectionCount = function (req, res) {

--- a/lib/base/get/odata_get.ts
+++ b/lib/base/get/odata_get.ts
@@ -497,6 +497,8 @@ export class ODataGetBase extends BaseRequestHandler.BaseRequestHandler {
 								//create metadata for expanded
 								for (var rel in ModelClass.relations) {
 									this._createMetadataForExpanded(instance, rel, req, ModelClass.relations[rel].modelTo, id, result.data);
+									// put the expanded results in "results" property like it's required by OData protocol and UI5 ODataModel works
+									result.data[rel] = { results: result.data[rel] };
 								}
 
 								//add metadata

--- a/lib/common/odata_common.js
+++ b/lib/common/odata_common.js
@@ -1,8 +1,8 @@
 "use strict";
-var enums = require('../constants/odata_enums');
+var enums = require("../constants/odata_enums");
 var odata_enums_1 = require("../constants/odata_enums");
-var lbConstants = require('../constants/loopback_constants');
-var log4js = require('log4js');
+var lbConstants = require("../constants/loopback_constants");
+var log4js = require("log4js");
 var oDataServerConfig;
 var logger = log4js.getLogger("odata");
 function _setConfig(config) {
@@ -46,7 +46,7 @@ function _getRequestType(req) {
 }
 function _isRequestCollection(req) {
     var retValue = false;
-    var reqParts = /^([^/(]+)(?:[(](.*)[)])?(?:[/]([A-Za-z]+))?/g.exec(req.params[0]);
+    var reqParts = /^([^/(]+)(?:[(](.*)[)])?(?:[/]([A-Za-z_]+))?/g.exec(req.params[0]);
     var models = req.app.models();
     models.forEach(function (model) {
         var plural = _getPluralForModel(model);
@@ -70,7 +70,7 @@ function _isRequestCollection(req) {
 }
 function _isRequestEntity(req) {
     var retValue = false;
-    var reqParts = /^([^/(]+)(?:[(](.*)[)])?(?:[/]([A-Za-z]+))?/g.exec(req.params[0]);
+    var reqParts = /^([^/(]+)(?:[(](.*)[)])?(?:[/]([A-Za-z_]+))?/g.exec(req.params[0]);
     var models = req.app.models();
     models.forEach(function (model) {
         var plural = _getPluralForModel(model);
@@ -136,7 +136,7 @@ function _getIdByPropertyType(sRawId, property) {
     return id;
 }
 function _getRequestModelClass(models, requestUri) {
-    var reqParts = /^([^/(]+)(?:[(](.*)[)])?(?:[/]([A-Za-z]+))?/g.exec(requestUri);
+    var reqParts = /^([^/(]+)(?:[(](.*)[)])?(?:[/]([A-Za-z_]+))?/g.exec(requestUri);
     if (!reqParts[3]) {
         return new Promise(function (resolve, reject) {
             _getModelClass(models, reqParts[1]).then(function (ModelClass) {
@@ -174,6 +174,18 @@ function _getRequestModelClass(models, requestUri) {
                         }
                         var idName = BaseModelClass.getIdName();
                         var sRequestId = _getIdByPropertyType(reqParts[2], BaseModelClass.definition.properties[idName]);
+                        if (modelRel[reqParts[3]].through) {
+                            _getModelClass(models, modelRel[reqParts[3]].model).then(function (ModelClass) {
+                                resolve({
+                                    modelClass: BaseModelClass,
+                                    requestId: sRequestId,
+                                    through: true,
+                                    relationName: reqParts[3],
+                                    relationModelClass: ModelClass
+                                });
+                                return;
+                            });
+                        }
                         switch (modelRel[reqParts[3]].type) {
                             case lbConstants.LB_REL_HASMANY:
                                 oFilter[sForeignKey] = sRequestId;

--- a/lib/odata.js
+++ b/lib/odata.js
@@ -279,11 +279,11 @@ var OData = (function () {
     OData.prototype.getGETCheckAccessContext = function (req, lbClass) {
         var re = /^\w*[(]([a-zA-Z0-9']*)[)]/g, match = re.exec(req.params[0]), _id, lbMethod;
         if (match) {
-            lbMethod = lbClass.find("findById", true);
+            lbMethod = lbClass.findMethodByName("findById", true);
             _id = match[1];
         }
         else {
-            lbMethod = lbClass.find("find", true);
+            lbMethod = lbClass.findMethodByName("find", true);
         }
         return {
             method: lbMethod,
@@ -295,7 +295,7 @@ var OData = (function () {
     };
     OData.prototype.getPOSTCheckAccessContext = function (req, lbClass) {
         var lbMethod;
-        lbMethod = lbClass.find("create", true);
+        lbMethod = lbClass.findMethodByName("create", true);
         return {
             method: lbMethod,
             req: req,
@@ -307,7 +307,7 @@ var OData = (function () {
     OData.prototype.getPUTCheckAccessContext = function (req, lbClass) {
         var re = /^\w*[(]([a-zA-Z0-9']*)[)]/g, match = re.exec(req.params[0]), _id, lbMethod;
         if (match) {
-            lbMethod = lbClass.find("updateAttributes", false);
+            lbMethod = lbClass.findMethodByName("updateAttributes", false);
             _id = match[1];
         }
         return {
@@ -321,7 +321,7 @@ var OData = (function () {
     OData.prototype.getDELETECheckAccessContext = function (req, lbClass) {
         var re = /^\w*[(]([a-zA-Z0-9']*)[)]/g, match = re.exec(req.params[0]), _id, lbMethod;
         if (match) {
-            lbMethod = lbClass.find("destroyById", true);
+            lbMethod = lbClass.findMethodByName("destroyById", true);
             _id = match[1];
         }
         return {

--- a/lib/odata.js
+++ b/lib/odata.js
@@ -1,16 +1,17 @@
 "use strict";
-var constants = require('./constants/odata_constants');
-var common = require('./common/odata_common');
-var ODataGetV4 = require('./v4/get/odata_get');
-var ODataPostV4 = require('./v4/post/odata_post');
-var ODataPutV4 = require('./v4/put/odata_put');
-var ODataDeleteV4 = require('./v4/delete/odata_delete');
-var ODataGetV2 = require('./v2/get/odata_get');
-var ODataPostV2 = require('./v2/post/odata_post');
-var ODataDeleteV2 = require('./v2/delete/odata_delete');
-var ODataPutV2 = require('./v2/put/odata_put');
-var fs = require('fs');
-var log4js = require('log4js');
+Object.defineProperty(exports, "__esModule", { value: true });
+var constants = require("./constants/odata_constants");
+var common = require("./common/odata_common");
+var ODataGetV4 = require("./v4/get/odata_get");
+var ODataPostV4 = require("./v4/post/odata_post");
+var ODataPutV4 = require("./v4/put/odata_put");
+var ODataDeleteV4 = require("./v4/delete/odata_delete");
+var ODataGetV2 = require("./v2/get/odata_get");
+var ODataPostV2 = require("./v2/post/odata_post");
+var ODataDeleteV2 = require("./v2/delete/odata_delete");
+var ODataPutV2 = require("./v2/put/odata_put");
+var fs = require("fs");
+var log4js = require("log4js");
 var odata_enums_1 = require("./constants/odata_enums");
 fs.stat('n_odata_server_log.json', function (err, stat) {
     var fileName = __dirname + '/log4js.json';
@@ -307,7 +308,7 @@ var OData = (function () {
     OData.prototype.getPUTCheckAccessContext = function (req, lbClass) {
         var re = /^\w*[(]([a-zA-Z0-9']*)[)]/g, match = re.exec(req.params[0]), _id, lbMethod;
         if (match) {
-            lbMethod = lbClass.findMethodByName("updateAttributes", false);
+            lbMethod = lbClass.findMethodByName("updateAll", false);
             _id = match[1];
         }
         return {

--- a/lib/odata.ts
+++ b/lib/odata.ts
@@ -516,7 +516,7 @@ export class OData {
 			lbMethod;
 
 		if (match) {
-			lbMethod = lbClass.findMethodByName("updateAttributes", false);
+			lbMethod = lbClass.findMethodByName("updateAll", false);
 			_id = match[1];
 		}
 

--- a/lib/odata.ts
+++ b/lib/odata.ts
@@ -467,10 +467,10 @@ export class OData {
 			_id,
 			lbMethod;
 		if (match) {
-			lbMethod = lbClass.find("findById", true);
+			lbMethod = lbClass.findMethodByName("findById", true);
 			_id = match[1];
 		} else {
-			lbMethod = lbClass.find("find", true);
+			lbMethod = lbClass.findMethodByName("find", true);
 		}
 
 		return {
@@ -491,7 +491,7 @@ export class OData {
 	private getPOSTCheckAccessContext(req: LoopbackRequest, lbClass: any) {
 		// find "create" method in sharedMethods --> this method has to be secured via a POST request
 		let lbMethod;
-		lbMethod = lbClass.find("create", true);
+		lbMethod = lbClass.findMethodByName("create", true);
 
 		return {
 			method: lbMethod,
@@ -516,7 +516,7 @@ export class OData {
 			lbMethod;
 
 		if (match) {
-			lbMethod = lbClass.find("updateAttributes", false);
+			lbMethod = lbClass.findMethodByName("updateAttributes", false);
 			_id = match[1];
 		}
 
@@ -543,7 +543,7 @@ export class OData {
 			lbMethod;
 
 		if (match) {
-			lbMethod = lbClass.find("destroyById", true);
+			lbMethod = lbClass.findMethodByName("destroyById", true);
 			_id = match[1];
 		}
 


### PR DESCRIPTION
When I included n-odata-server component into the LoopBack 3 application, I got a fatal error that method "find" is deprecated. So did the needed changes to fix this issue.